### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 license = "MIT"
 authors = ["Noah Daniels <noah_daniels@uri.edu>", "Najib Ishaq <najib_ishaq@zoho.com>", "Colin O'Connor <colin_oconnor@uri.edu>"]
 description = "A wrapper around the image crate, for CSC 411"
+repository = "https://github.com/ndaniels/csc411_image"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
to allow crates.io, the rust-digger and others to link to it