### PR TITLE
Minor error in documentation for `GrayImage`

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -124,7 +124,7 @@ impl Write for RgbImage {
 }
 
 impl Read for GrayImage {
-    /// Reads an GrayImage to either a filename or stdout
+    /// Reads an GrayImage from either a filename or stdin
     ///
     /// # Arguments
     ///


### PR DESCRIPTION
Fixes a minor documentation error with `GrayImage`. How did I miss this when I took 411? LOL